### PR TITLE
✨ [Feat] 추억 상세 조회 api 구현

### DIFF
--- a/src/main/java/com/likelion/tostar/domain/articles/controller/ArticleController.java
+++ b/src/main/java/com/likelion/tostar/domain/articles/controller/ArticleController.java
@@ -56,8 +56,9 @@ public class ArticleController {
      */
     @GetMapping("{articleId}")
     public ResponseEntity<?> searchArticleDetail(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable("articleId")Long articleId) {
-        return articleService.searchArticleDetail(articleId);
+        return articleService.searchArticleDetail(customUserDetails.getId(), articleId);
     }
 
     /**

--- a/src/main/java/com/likelion/tostar/domain/articles/dto/ArticleSearchDetailResponseDto.java
+++ b/src/main/java/com/likelion/tostar/domain/articles/dto/ArticleSearchDetailResponseDto.java
@@ -1,0 +1,24 @@
+package com.likelion.tostar.domain.articles.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class ArticleSearchDetailResponseDto {
+
+    private Long articleId;
+    private String title;
+    private String content;
+    private List<ArticleSearchListResponseDto.ImageDto> images; // 게시글 이미지들
+    private boolean isOwner; // 게시글의 주인 여부
+
+    @Builder
+    @Data
+    public static class ImageDto { // 게시글 이미지에 대한 정보
+        private Long imageId;
+        private String url;
+    }
+}

--- a/src/main/java/com/likelion/tostar/domain/articles/service/ArticleService.java
+++ b/src/main/java/com/likelion/tostar/domain/articles/service/ArticleService.java
@@ -26,5 +26,5 @@ public interface ArticleService {
     ResponseEntity<?> getArticlesWithoutFriends(Long userId, int page, int size);
 
     // 추억 상세 조회
-    ResponseEntity<?> searchArticleDetail(Long articleId);
+    ResponseEntity<?> searchArticleDetail(Long userId, Long articleId);
 }

--- a/src/main/java/com/likelion/tostar/domain/articles/service/ArticleServiceImpl.java
+++ b/src/main/java/com/likelion/tostar/domain/articles/service/ArticleServiceImpl.java
@@ -3,6 +3,7 @@ package com.likelion.tostar.domain.articles.service;
 import com.likelion.tostar.domain.articles.dto.ArticleCreateModifyRequestDto;
 import com.likelion.tostar.domain.articles.dto.ArticlePostResponseDto;
 import com.likelion.tostar.domain.articles.dto.ArticlePostResponseDto.ImageResponseDto;
+import com.likelion.tostar.domain.articles.dto.ArticleSearchDetailResponseDto;
 import com.likelion.tostar.domain.articles.dto.ArticleSearchListResponseDto;
 import com.likelion.tostar.domain.articles.entity.Article;
 import com.likelion.tostar.domain.articles.entity.ArticleImage;
@@ -154,6 +155,23 @@ public class ArticleServiceImpl implements ArticleService {
                 .body(ApiResponse.onSuccess("추억 삭제에 성공했습니다."));
     }
 
+
+    /**
+     * 추억 상세 조회
+     */
+    @Override
+    public ResponseEntity<?> searchArticleDetail(Long userId, Long articleId) {
+        // 404 : 존재하지 않는 추억
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._ARTICLE_NOT_FOUND));
+
+        ArticleSearchDetailResponseDto responseDto = buildArticleDetailResponse(article, userId);
+
+        // 200 : 응답 반환
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.onSuccess(responseDto));
+    }
+
     /**
      * 나의 게시글을 최신순으로 조회
      */
@@ -172,7 +190,7 @@ public class ArticleServiceImpl implements ArticleService {
         // 게시글 정보 빌드 (response.result)
         List<ArticleSearchListResponseDto> responseDtos = new ArrayList<>();
         for (Article article : articlePage.getContent()) {
-            ArticleSearchListResponseDto responseDto = buildArticleResponse(article, userId);
+            ArticleSearchListResponseDto responseDto = buildArticleListResponse(article, userId);
             responseDtos.add(responseDto);
         }
 
@@ -200,7 +218,7 @@ public class ArticleServiceImpl implements ArticleService {
         // 게시글 정보 빌드 (response.result)
         List<ArticleSearchListResponseDto> responseDtos = new ArrayList<>();
         for (Article article : articlePage.getContent()) {
-            ArticleSearchListResponseDto responseDto = buildArticleResponse(article, userId);
+            ArticleSearchListResponseDto responseDto = buildArticleListResponse(article, userId);
             responseDtos.add(responseDto);
         }
 
@@ -210,6 +228,9 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
 
+    /**
+     * 나와 친구를 제외한 친구들의 추억 조회
+     */
     @Override
     public ResponseEntity<?> getArticlesWithoutFriends(Long userId, int page, int size) {
         // 404 : 토큰에 해당하는 회원이 실제로 존재하는지 확인
@@ -232,20 +253,13 @@ public class ArticleServiceImpl implements ArticleService {
         List<ArticleSearchListResponseDto> responseDtos = new ArrayList<>();
         for (Article article : articlePage.getContent()) {
             // article을 가지고 ArticleSearchListResponseDto 빌드
-            ArticleSearchListResponseDto responseDto = buildArticleResponse(article, userId);
+            ArticleSearchListResponseDto responseDto = buildArticleListResponse(article, userId);
             responseDtos.add(responseDto);
         }
 
         // 응답 반환
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.onSuccess(responseDtos));    }
-
-    /**
-     * 추억 상세 조회
-     */
-    @Override
-    public ResponseEntity<?> searchArticleDetail(Long articleId) {
-        return null;
+                .body(ApiResponse.onSuccess(responseDtos));
     }
 
 
@@ -299,8 +313,29 @@ public class ArticleServiceImpl implements ArticleService {
         return ResponseEntity.status(200).body(ApiResponse.onSuccess(responseDto));
     }
 
-    // article 가지고 ArticleSearchListResponseDto 빌드해주는 메서드
-    private ArticleSearchListResponseDto buildArticleResponse(Article article, Long userId) {
+    // article -> ArticleSearchDetailResponseDto 빌드해주는 메서드
+    private ArticleSearchDetailResponseDto buildArticleDetailResponse(Article article, Long userId) {
+        // 이미지 리스트 빌드 - images
+        List<ArticleSearchListResponseDto.ImageDto> imageDtos = new ArrayList<>();
+        for (ArticleImage image : article.getImages()) {
+            ArticleSearchListResponseDto.ImageDto imageDto = ArticleSearchListResponseDto.ImageDto.builder()
+                    .imageId(image.getId())
+                    .url(image.getUrl())
+                    .build();
+            imageDtos.add(imageDto);
+        }
+        // ArticleSearchDetailResponseDto 빌드
+        return ArticleSearchDetailResponseDto.builder()
+                .articleId(article.getId())
+                .title(article.getTitle())
+                .content(article.getContent())
+                .images(imageDtos)
+                .isOwner(article.getUser().getId().equals(userId))
+                .build();
+    }
+
+    // article -> ArticleSearchListResponseDto 빌드해주는 메서드
+    private ArticleSearchListResponseDto buildArticleListResponse(Article article, Long userId) {
         // 작성자 정보 빌드 - author
         User author = article.getUser();
         ArticleSearchListResponseDto.AuthorDto authorDto = ArticleSearchListResponseDto.AuthorDto.builder()


### PR DESCRIPTION
### ✨ 이슈 번호
- #87 

### 📄 작업 내용 

추억 상세 조회 api 구현

- 200 (주인 아닌 경우 & 게시글 이미지 있는 경우)
<img width="725" alt="image" src="https://github.com/user-attachments/assets/74803e6b-d539-4451-b48b-beff1af0a7af">

- 200 (주인인 경우 & 게시글 이미지 존재하지 않는 경우)
<img width="520" alt="image" src="https://github.com/user-attachments/assets/7c479db8-7c34-427d-a7ea-9f632de72644">


- 404(추억 찾을 수 없음)
<img width="677" alt="image" src="https://github.com/user-attachments/assets/bba016af-3727-4d0a-8418-4faa6e006582">

### ℹ️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 📌 PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Reviewers, Assignees, Labels 을 올바르게 작성하였습니다.
- [x] (중요!) 병합 브랜치를 dev로 선택하였습니다

Closes #87 
